### PR TITLE
fix coolify deployment by defaulting secret key

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -37,7 +37,10 @@ services:
     environment:
       ROLE: web
       DJANGO_SETTINGS_MODULE: project.settings
-      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:?}
+      # Provide a default so preview deployments don't fail when the
+      # variable isn't explicitly set. Production deployments should
+      # override this with a secure value.
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-insecure-dev-key-change-in-production}
       DEBUG: ${DEBUG:-False}
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-}
       


### PR DESCRIPTION
## Summary
- provide default `DJANGO_SECRET_KEY` so preview deployments don't fail if env var missing

## Testing
- `pytest -q --ds=project.settings_test` *(fails: ImportError: cannot import name 'AxeBuilder' from 'axe_playwright_python')*

------
https://chatgpt.com/codex/tasks/task_e_68c5de23e8b88333a772a47e7d024bca